### PR TITLE
tests: use SSH for most tests

### DIFF
--- a/tests/test_opkg.py
+++ b/tests/test_opkg.py
@@ -1,8 +1,8 @@
-def test_opkg_procd_installed(shell_command):
-    assert "procd" in "\n".join(shell_command.run("opkg list-installed")[0])
+def test_opkg_procd_installed(ssh_command):
+    assert "procd" in "\n".join(ssh_command.run("opkg list-installed")[0])
 
 
-def test_opkg_install_tmate(shell_command):
-    shell_command.run("opkg update")
-    shell_command.run("opkg install tmate")
-    assert "tmate" in "\n".join(shell_command.run("opkg list-installed")[0])
+def test_opkg_install_tmate(ssh_command):
+    ssh_command.run("opkg update")
+    ssh_command.run("opkg install tmate")
+    assert "tmate" in "\n".join(ssh_command.run("opkg list-installed")[0])


### PR DESCRIPTION
When using real devices, this should add a better reliability.