### PR TITLE
conftest: remove prysk typo

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,6 @@
 import pytest
 import json
 
-import prysk
-
 
 def pytest_addoption(parser):
     parser.addoption("--target", action="store", default="main")


### PR DESCRIPTION
While Prysk is planed to be used eventually, it's not yet working. Remove the accidental import.