### PR TITLE
tests: add simple sysupgrade normal and -u test

### DIFF
--- a/targets/qemu-x86-64.yaml
+++ b/targets/qemu-x86-64.yaml
@@ -1,6 +1,7 @@
 features:
   - online
   - opkg
+  - rootfs
 
 targets:
   main:
@@ -27,7 +28,6 @@ targets:
           username: root
       - SSHDriver:
           username: root
-          explicit_scp_mode: True
       - QEMUNetworkStrategy: {}
 
 tools:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,7 @@
 import re
+import tarfile
 
+import pytest
 from conftest import ubus_call
 
 
@@ -23,6 +25,26 @@ def test_ubus_system_board(shell_command):
 
 def test_ssh(ssh_command):
     ssh_command.run("true")
+
+
+@pytest.mark.lg_feature("rootfs")
+def test_sysupgrade_backup(ssh_command):
+    ssh_command.run("sysupgrade -b /tmp/backup.tar.gz")
+    ssh_command.get("/tmp/backup.tar.gz")
+
+    backup = tarfile.open("backup.tar.gz", "r")
+    assert "etc/config/dropbear" in backup.getnames()
+    ssh_command.run("rm -rf /tmp/backup.tar.gz")
+
+
+@pytest.mark.lg_feature("rootfs")
+def test_sysupgrade_backup_u(ssh_command):
+    ssh_command.run("sysupgrade -u -b /tmp/backup.tar.gz")
+    ssh_command.get("/tmp/backup.tar.gz")
+
+    backup = tarfile.open("backup.tar.gz", "r")
+    assert "etc/config/dropbear" not in backup.getnames()
+    ssh_command.run("rm -rf /tmp/backup.tar.gz")
 
 
 def test_kernel_errors(shell_command):


### PR DESCRIPTION
Add simple sysupgrade validation for normal and -u generated tar.gz

We currently check if dropbear config file is included in the produced tar and if it's excluded with the -u option (assuming dropbear is the exact version the package manage installed)

---

@aparcar just a simple thing to test scp transfer. I enabled the SSH driver to every device also introduced --flashed as sysupgrade tar can be generated only with flashed scenario and doesn't work with initramfs.

(current main with APK should have this test fail with -u and with the cumulative fixes working)