### PR TITLE
targets: use login_prompt not console_ready

### DIFF
--- a/targets/qemu-armsr-armv8.yaml
+++ b/targets/qemu-armsr-armv8.yaml
@@ -21,9 +21,8 @@ targets:
           extra_args: "-device virtio-rng-pci -netdev user,id=wan -device virtio-net-pci,netdev=wan"
           nic: user,model=virtio-net-pci,net=192.168.1.0/24,id=lan
       - ShellDriver:
-          console_ready: Please press Enter to activate this console.
+          login_prompt: Please press Enter to activate this console.
           prompt: 'root@[\w()]+:[^ ]+ '
-          login_prompt: built-in shell (ash)
           await_login_timeout: 15
           username: root
       - SSHDriver: {}

--- a/targets/qemu-malta-be.yaml
+++ b/targets/qemu-malta-be.yaml
@@ -22,9 +22,8 @@ targets:
           nic: user,model=pcnet,net=192.168.1.0/24,id=lan
           kernel: firmware
       - ShellDriver:
-          console_ready: Please press Enter to activate this console.
+          login_prompt: Please press Enter to activate this console.
           prompt: 'root@[\w()]+:[^ ]+ '
-          login_prompt: built-in shell (ash)
           await_login_timeout: 15
           username: root
       - SSHDriver: {}

--- a/targets/qemu-x86-64.yaml
+++ b/targets/qemu-x86-64.yaml
@@ -21,9 +21,8 @@ targets:
           nic: user,model=virtio-net-pci,net=192.168.1.0/24,id=lan
           disk: firmware
       - ShellDriver:
-          console_ready: Please press Enter to activate this console.
+          login_prompt: Please press Enter to activate this console.
           prompt: 'root@[\w()]+:[^ ]+ '
-          login_prompt: built-in shell (ash)
           await_login_timeout: 15
           username: root
       - SSHDriver:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def pytest_addoption(parser):
     parser.addoption("--firmware", action="store", default="firmware.bin")
 
 
-def ubus_call(command, namespace, method, params):
+def ubus_call(command, namespace, method, params={}):
     output, _, exitcode = command.run(
         f"ubus call {namespace} {method} '{json.dumps(params)}'"
     )


### PR DESCRIPTION
Labgrid doesn't silence the Kernel since the login logic is different for their devices compared to how OpenWrt works. Use a workaround to trigger Kernel silencing.