### PR TITLE
CI: upload named artifact for each target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,5 +67,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: console
+          name: console-${{ matrix.target }}
           path: console_*


### PR DESCRIPTION
We currently overwrite the console artifact with the last build completed. To provent this export named artifact by using the matrix.target value to differentiate them.