### PR TITLE
Update /etc/hosts when changing hostname

### DIFF
--- a/ansible/playbook_labgrid.yml
+++ b/ansible/playbook_labgrid.yml
@@ -5,6 +5,13 @@
         name: "{{ inventory_hostname }}"
       become: yes
 
+    - name: Write hostname to /etc/hosts
+      ansible.builtin.replace:
+        path: /etc/hosts
+        regexp: '127\.0\.0\.1\s.+'
+        replace: "127.0.0.1\t{{ inventory_hostname }}"
+      become: yes
+
     - name: Install required packages
       apt:
         name:


### PR DESCRIPTION
We should update the entry for localhost in /etc/hosts when changing the hostname.