### PR TITLE
Tests: Style Optimization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,10 +72,7 @@ def pytest_sessionfinish(session):
 
 
 def ubus_call(command, namespace, method, params={}):
-    output, _, exitcode = command.run(
-        f"ubus call {namespace} {method} '{json.dumps(params)}'"
-    )
-    assert exitcode == 0
+    output = command.run_check(f"ubus call {namespace} {method} '{json.dumps(params)}'")
 
     try:
         return json.loads("\n".join(output))

--- a/tests/test_apk.py
+++ b/tests/test_apk.py
@@ -8,5 +8,8 @@ def test_apk_procd_installed(shell_command):
 
 @pytest.mark.lg_feature(["online", "apk"])
 def test_apk_add_ucert(ssh_command):
-    ssh_command.run("apk add ucert")
-    assert "ucert" in "\n".join(ssh_command.run("apk list | grep ucert")[0])
+    try:
+        ssh_command.run_check("apk add ucert")
+        assert "ucert" in "\n".join(ssh_command.run_check("apk list | grep ucert"))
+    finally:
+        ssh_command.run("apk del ucert")

--- a/tests/test_apk.py
+++ b/tests/test_apk.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.lg_feature("apk")
 def test_apk_procd_installed(shell_command):
-    assert "procd" in "\n".join(shell_command.run("apk list")[0])
+    assert "procd" in "\n".join(shell_command.run_check("apk list"))
 
 
 @pytest.mark.lg_feature(["online", "apk"])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -61,22 +61,26 @@ def test_ssh(ssh_command):
 
 @pytest.mark.lg_feature("rootfs")
 def test_sysupgrade_backup(ssh_command):
-    ssh_command.run("sysupgrade -b /tmp/backup.tar.gz")
-    ssh_command.get("/tmp/backup.tar.gz")
+    try:
+        ssh_command.run("sysupgrade -b /tmp/backup.tar.gz")
+        ssh_command.get("/tmp/backup.tar.gz")
 
-    backup = tarfile.open("backup.tar.gz", "r")
-    assert "etc/config/dropbear" in backup.getnames()
-    ssh_command.run("rm -rf /tmp/backup.tar.gz")
+        backup = tarfile.open("backup.tar.gz", "r")
+        assert "etc/config/dropbear" in backup.getnames()
+    finally:
+        ssh_command.run("rm -rf /tmp/backup.tar.gz")
 
 
 @pytest.mark.lg_feature("rootfs")
 def test_sysupgrade_backup_u(ssh_command):
-    ssh_command.run("sysupgrade -u -b /tmp/backup.tar.gz")
-    ssh_command.get("/tmp/backup.tar.gz")
+    try:
+        ssh_command.run("sysupgrade -u -b /tmp/backup.tar.gz")
+        ssh_command.get("/tmp/backup.tar.gz")
 
-    backup = tarfile.open("backup.tar.gz", "r")
-    assert "etc/config/dropbear" not in backup.getnames()
-    ssh_command.run("rm -rf /tmp/backup.tar.gz")
+        backup = tarfile.open("backup.tar.gz", "r")
+        assert "etc/config/dropbear" not in backup.getnames()
+    finally:
+        ssh_command.run("rm -rf /tmp/backup.tar.gz")
 
 
 def test_kernel_errors(shell_command):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -8,16 +8,17 @@ from conftest import ubus_call
 
 
 def test_shell(shell_command):
-    shell_command.run("true")
+    shell_command.run_check("true")
 
 
 def test_echo(shell_command):
-    output = shell_command.run("echo 'hello world'")
-    assert output[0][0] == "hello world"
+    [output] = shell_command.run_check("echo 'hello world'")
+    assert output == "hello world"
 
 
 def test_uname(shell_command):
-    assert "GNU/Linux" in shell_command.run("uname -a")[0][0]
+    [output] = shell_command.run_check("uname -a")
+    assert "GNU/Linux" in output
 
 
 def test_ubus_system_board(shell_command, results_bag):
@@ -39,7 +40,7 @@ def test_ubus_system_board(shell_command, results_bag):
 
 
 def test_free_memory(shell_command, results_bag):
-    used_memory = int(shell_command.run("free -m")[0][1].split()[2])
+    used_memory = int(shell_command.run_check("free -m")[1].split()[2])
 
     assert used_memory > 10000, "Used memory is more than 100MB"
     results_bag["used_memory"] = used_memory
@@ -56,13 +57,13 @@ def test_dropbear_startup(shell_command):
 
 
 def test_ssh(ssh_command):
-    ssh_command.run("true")
+    ssh_command.run_check("true")
 
 
 @pytest.mark.lg_feature("rootfs")
 def test_sysupgrade_backup(ssh_command):
     try:
-        ssh_command.run("sysupgrade -b /tmp/backup.tar.gz")
+        ssh_command.run_check("sysupgrade -b /tmp/backup.tar.gz")
         ssh_command.get("/tmp/backup.tar.gz")
 
         backup = tarfile.open("backup.tar.gz", "r")
@@ -74,7 +75,7 @@ def test_sysupgrade_backup(ssh_command):
 @pytest.mark.lg_feature("rootfs")
 def test_sysupgrade_backup_u(ssh_command):
     try:
-        ssh_command.run("sysupgrade -u -b /tmp/backup.tar.gz")
+        ssh_command.run_check("sysupgrade -u -b /tmp/backup.tar.gz")
         ssh_command.get("/tmp/backup.tar.gz")
 
         backup = tarfile.open("backup.tar.gz", "r")
@@ -84,7 +85,7 @@ def test_sysupgrade_backup_u(ssh_command):
 
 
 def test_kernel_errors(shell_command):
-    logread = "\n".join(shell_command.run("logread")[0])
+    logread = "\n".join(shell_command.run_check("logread"))
 
     error_patterns = [
         r"traps:.*general protection",

--- a/tests/test_opkg.py
+++ b/tests/test_opkg.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.lg_feature("opkg")
 def test_opkg_procd_installed(ssh_command):
-    assert "procd" in "\n".join(ssh_command.run("opkg list-installed")[0])
+    assert "procd" in "\n".join(ssh_command.run_check("opkg list-installed"))
 
 
 @pytest.mark.lg_feature(["online", "opkg"])

--- a/tests/test_opkg.py
+++ b/tests/test_opkg.py
@@ -8,6 +8,9 @@ def test_opkg_procd_installed(ssh_command):
 
 @pytest.mark.lg_feature(["online", "opkg"])
 def test_opkg_install_ucert(ssh_command):
-    ssh_command.run("opkg update")
-    ssh_command.run("opkg install ucert")
-    assert "ucert" in "\n".join(ssh_command.run("opkg list-installed")[0])
+    try:
+        ssh_command.run_check("opkg update")
+        ssh_command.run_check("opkg install ucert")
+        assert "ucert" in "\n".join(ssh_command.run_check("opkg list-installed"))
+    finally:
+        ssh_command.run("opkg remove ucert")

--- a/tests/test_wan.py
+++ b/tests/test_wan.py
@@ -11,32 +11,34 @@ def check_download(
     remove=True,
     filename="index.html",
 ):
-    stdout, stderr, exitcode = command.run(f"wget {url} -O {filename}")
-    if expect_stdout:
-        found = False
-        for line in stdout:
-            if expect_stdout in line:
-                found = True
-                break
-        assert found, f"Expected output '{expect_stdout}' not found in {stdout}"
+    try:
+        stdout, stderr, exitcode = command.run(f"wget {url} -O {filename}")
+        if expect_stdout:
+            found = False
+            for line in stdout:
+                if expect_stdout in line:
+                    found = True
+                    break
+            assert found, f"Expected output '{expect_stdout}' not found in {stdout}"
 
-    if expect_stderr:
-        found = False
-        for line in stderr:
-            if expect_stderr in line:
-                found = True
-                break
-        assert found, f"Expected error '{expect_stderr}' not found in {stderr}"
+        if expect_stderr:
+            found = False
+            for line in stderr:
+                if expect_stderr in line:
+                    found = True
+                    break
+            assert found, f"Expected error '{expect_stderr}' not found in {stderr}"
 
-    assert expect_exitcode == exitcode, (
-        f"Expected exit code {expect_exitcode} not found in {exitcode}"
-    )
-    if expect_content:
-        assert expect_content in command.run(f"cat {url.split('/')[-1]}")[0], (
-            f"Expected content '{expect_content}' not found in {url.split('/')[-1]}"
+        assert expect_exitcode == exitcode, (
+            f"Expected exit code {expect_exitcode} not found in {exitcode}"
         )
-    if remove:
-        command.run(f"rm {filename}")
+        if expect_content:
+            assert expect_content in command.run(f"cat {url.split('/')[-1]}")[0], (
+                f"Expected content '{expect_content}' not found in {url.split('/')[-1]}"
+            )
+    finally:
+        if remove:
+            command.run(f"rm {filename}")
 
 
 @pytest.mark.lg_feature("online")


### PR DESCRIPTION
This PR implements some best practices across the tests.
This should be a no-op regarding test coverage.

It implements the following best practices:

* Tests should not change the system state. An easy way to implement this is use `try .. finally` and clean up your changes in the `finally` block.
* Use `run_check()` instead of `run()` during tests. `run_check()` already checks, if `rc==0` and raises an Exception if not. This let's tests fail, even if one of the steps fails.
* Use the `[line0] = shell.run_check()` syntax, if we only want expect a single line of `stdout`. This way the test will fail, if we get more than one line - even if the first contains the expected value.

TODO:

* [x] Test on hardware before merging