### PR TITLE
labnet: add bananapi_bpi-r64 in labgrid-hsn

### DIFF
--- a/labnet.yaml
+++ b/labnet.yaml
@@ -78,6 +78,7 @@ labs:
     maintainers: "@jonasjelonek"
     devices:
       - genexis_pulse-ex400
+      - bananapi_bpi-r64
     developers:
       - aparcar
       - jonasjelonek


### PR DESCRIPTION
Add `bananapi_bpi-r64` to labgrid-hsn lab since this device is available there.