### PR TITLE
ansible: some fixes and changes

### DIFF
--- a/ansible/files/exporter/dnsmasq.conf
+++ b/ansible/files/exporter/dnsmasq.conf
@@ -1,3 +1,6 @@
+# Turn off DNS functionality
+port=0
+
 # DHCP Configuration
 {% for vlan in range(0, vlans) %}
 interface=vlan{{ vlan + 100 }}

--- a/ansible/files/exporter/netplan.yaml
+++ b/ansible/files/exporter/netplan.yaml
@@ -1,10 +1,9 @@
 network:
   version: 2
-  # renderer: NetworkManager
   ethernets:
     {{ ethernet_interface }}:
       addresses:
-        - 192.168.128.1/2
+        - 192.168.128.1/24
   vlans:
   {% for vlan in range(0, vlans) %}
     vlan{{ vlan + 100 }}:

--- a/ansible/playbook_labgrid.yml
+++ b/ansible/playbook_labgrid.yml
@@ -176,6 +176,35 @@
       notify:
         - Restart dnsmasq
 
+    - name: Configure network with netplan
+      block:
+        - name: Check if netplan is available
+          ansible.builtin.raw: which netplan
+          register: which_res
+
+        - name: Stop if netplan not available
+          ansible.builtin.debug:
+            msg: "netplan is not available! Please switch your host to using netplan for network configuration"
+          when: "which_res.rc != 0"
+
+        - name: Stat host specific netplan configuration
+          ansible.builtin.stat:
+            path: files/exporter/netplan-{{ ansible_hostname }}.yaml
+          register: host_specific_netplan_conf
+          delegate_to: localhost
+          become: false
+
+        - name: Configure netplan using host specific config
+          ansible.builtin.template:
+            src: files/exporter/netplan-{{ ansible_host }}.yaml
+            dest: /etc/netplan/labnet.yaml
+          when: host_specific_netplan_conf.stat.exists
+
+        - name: Apply netplan config
+          ansible.builtin.command:
+            cmd: netplan apply
+          become: true
+
     - name: Stat host specific dnsmasq configuration
       ansible.builtin.stat:
         path: files/exporter/dnsmasq-{{ ansible_hostname }}.conf

--- a/ansible/playbook_labgrid.yml
+++ b/ansible/playbook_labgrid.yml
@@ -155,6 +155,8 @@
       file:
         path: /srv/tftp/{{ item }}
         state: directory
+        owner: "labgrid-dev"
+        group: "labgrid-dev"
         mode: "0755"
       loop: "{{ hostvars[inventory_hostname]['labs'][inventory_hostname]['devices'] }}"
 


### PR DESCRIPTION
fixes should be good to go.

important change:

use netplan by default for configuring the network how we need it to be. When netplan is not available, Ansible stops. This might be the case on Debian hosts. Ubuntu uses netplan by default for some time.

ping @aparcar 
