### PR TITLE
use pdudaemon to control power of DUTs

### DIFF
--- a/ansible/files/exporter/labgrid-aparcar.yaml
+++ b/ansible/files/exporter/labgrid-aparcar.yaml
@@ -36,9 +36,9 @@ labgrid-aparcar-genexis_pulse-ex400:
   USBSerialPort:
     match:
       ID_PATH: platform-xhci-hcd.1-usb-0:1.4:1.0
-  NetworkPowerPort:
-    model: ubus
-    host: "http://192.168.128.2/ubus"
+  PDUDaemonPort:
+    host: localhost:16421
+    pdu: 192.168.128.2
     index: 1
   TFTPProvider:
     internal: "/srv/tftp/genexis_pulse-ex400/"

--- a/ansible/files/exporter/pdudaemon.conf
+++ b/ansible/files/exporter/pdudaemon.conf
@@ -1,0 +1,9 @@
+{
+    "daemon": {
+        "hostname": "localhost",
+        "port": 16421,
+        "logging_level": "DEBUG",
+        "listener": "http"
+    },
+    "pdus": { }
+}

--- a/ansible/files/exporter/pdudaemon.service
+++ b/ansible/files/exporter/pdudaemon.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Control and Queueing daemon for PDUs
+
+[Service]
+ExecStart=/usr/local/bin/pdudaemon --journal --conf=/etc/pdudaemon/pdudaemon.conf
+Type=simple
+DynamicUser=yes
+StateDirectory=pdudaemon
+ProtectHome=trueq
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/playbook_labgrid.yml
+++ b/ansible/playbook_labgrid.yml
@@ -114,6 +114,10 @@
           - iptables
           - iptables-persistent
           - git
+          - pkg-config
+          - libsystemd-dev
+          - build-essential
+          - python3-dev
         state: present
         update_cache: yes
 
@@ -167,6 +171,60 @@
 
       notify:
         - Restart labgrid-exporter
+
+    - name: Setup pdudaemon
+      block:
+        - name: Install pdudaemon via pipx
+          community.general.pipx:
+            name: pdudaemon
+            source: git+https://github.com/jonasjelonek/pdudaemon.git@main
+            state: latest
+          environment:
+            PIPX_HOME: /opt/pipx/
+            PIPX_BIN_DIR: /usr/local/bin
+          become: true
+
+        - name: Create pdudaemon directory
+          ansible.builtin.file:
+            path: /etc/pdudaemon
+            state: directory
+            mode: 0755
+
+        - name: Deploy pdudaemon systemd unit
+          ansible.builtin.template:
+            src: files/exporter/pdudaemon.service
+            dest: /etc/systemd/system/pdudaemon.service
+
+        - name: Start and enable pdudaemon
+          ansible.builtin.systemd_service:
+            name: pdudaemon
+            state: restarted
+            enabled: yes
+            daemon_reload: yes
+
+        - name: Stat host specific pdudaemon configuration
+          ansible.builtin.stat:
+            path: files/exporter/pdudaemon-{{ ansible_hostname }}.conf
+          register: host_specific_pdudaemon_conf
+          delegate_to: localhost
+          become: false
+
+        - name: Configure pdudaemon using host specific config
+          template:
+            src: files/exporter/pdudaemon-{{ ansible_host }}.conf
+            dest: /etc/pdudaemon/pdudaemon.conf
+          notify:
+            - Restart pdudaemon
+          when: host_specific_pdudaemon_conf.stat.exists
+
+        - name: Otherwise use general config
+          template:
+            src: files/exporter/pdudaemon.conf
+            dest: /etc/pdudaemon/pdudaemon.conf
+          notify:
+            - Restart pdudaemon
+          when: not host_specific_pdudaemon_conf.stat.exists
+
 
     - name: Install dnsmasq
       apt:
@@ -328,6 +386,12 @@
       systemd:
         daemon_reload: yes
         name: labgrid-coordinator
+        state: restarted
+
+    - name: Restart pdudaemon
+      systemd:
+        daemon_reload: yes
+        name: pdudaemon
         state: restarted
 
     - name: Restart dnsmasq

--- a/targets/bananapi_bpi-r64.yaml
+++ b/targets/bananapi_bpi-r64.yaml
@@ -6,7 +6,7 @@ targets:
       RemotePlace:
         name: !template "$LG_PLACE"
     drivers:
-      - NetworkPowerDriver: {}
+      - PDUDaemonDriver: {}
       - TFTPProviderDriver: {}
       - SerialDriver:
           txdelay: 0.01

--- a/targets/genexis_pulse-ex400.yaml
+++ b/targets/genexis_pulse-ex400.yaml
@@ -6,7 +6,7 @@ targets:
       RemotePlace:
         name: !template "$LG_PLACE"
     drivers:
-      NetworkPowerDriver: {}
+      PDUDaemonDriver: {}
       TFTPProviderDriver: {}
       SerialDriver:
         txdelay: 0.01


### PR DESCRIPTION
Add ansible tasks to setup pdudaemon properly to allow controlling the power state of DUTs via that rather than using labgrid's own drivers, as labgrid itself suggests that.

Installing pdudaemon currently uses my fork which adds a ubus driver for OpenWrt PoE switches. (PR pending in upstream pdudaemon)

Switch Genexis Pulse-EX400 and BananaPi R64 devices to pdudaemon.