### PR TITLE
labgrid-hsn: new devices

### DIFF
--- a/labnet.yaml
+++ b/labnet.yaml
@@ -69,6 +69,11 @@ devices:
     target: mpc85xx-p1020
     firmware: initramfs-kernel.bin
 
+  iei_puzzle-m902:
+    name: iEi Puzzle-M902
+    target: mvebu-cortexa72
+    firmware: initramfs-kernel.bin
+
 labs:
   labgrid-aparcar:
     proxy: labgrid-aparcar
@@ -118,6 +123,8 @@ labs:
     devices:
       - genexis_pulse-ex400
       - bananapi_bpi-r64
+      - bananapi_bpi-r4
+      - iei_puzzle-m902
     developers:
       - aparcar
       - jonasjelonek

--- a/targets/iei_puzzle-m902.yaml
+++ b/targets/iei_puzzle-m902.yaml
@@ -1,0 +1,34 @@
+targets:
+  main:
+    features:
+      - wan_port
+    resources:
+      RemotePlace:
+        name: !template "$LG_PLACE"
+    drivers:
+      - PDUDaemonDriver: {}
+      - TFTPProviderDriver: {}
+      - SerialDriver:
+          txdelay: 0.01
+      - UBootDriver:
+          prompt: "Marvell>>"
+          init_commands:
+            - dhcp
+          boot_command: bootm $loadaddr#$bootconf
+      - ShellDriver:
+          prompt: 'root@[\w()]+:[^ ]+ '
+          login_prompt: Please press Enter to activate this console.
+          await_login_timeout: 15
+          login_timeout: 120
+          post_login_settle_time: 5
+          username: root
+      - UBootTFTPStrategy: {}
+      - SSHDriver:
+          connection_timeout: 120.0
+          explicit_scp_mode: True
+
+images:
+  root: !template $LG_IMAGE
+
+imports:
+  - ../strategies/tftpstrategy.py


### PR DESCRIPTION
Add BananaPi-R4 as available device in labgrid-hsn.

Add device description for iEi Puzzle M902 and add it as available device for labgrid-hsn.