### PR TITLE
labnet: add new devices to wigyorilab

### DIFF
--- a/ansible/files/exporter/labgrid-wigyori.yaml
+++ b/ansible/files/exporter/labgrid-wigyori.yaml
@@ -1,12 +1,12 @@
-labgrid-wigyori-pine64_pine64-plus:
+labgrid-wigyori-olimex_a10-olinuxino-lime:
   location: wigyorilab
   USBSerialPort:
     match:
       ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.1:1.0
     speed: 115200
   TFTPProvider:
-    internal: "/tftpboot/pine64_pine64-plus"
-    external: "pine64_pine64-plus"
+    internal: "/tftpboot/olimex_a10-olinuxino-lime"
+    external: "olimex_a10-olinuxino-lime"
     external_ip: 192.168.101.1
   NetworkService:
     address: "192.168.1.1%eth0.201"
@@ -16,15 +16,15 @@ labgrid-wigyori-pine64_pine64-plus:
       ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:2:1.0
     index: 1
 
-labgrid-wigyori-xunlong_orangepi-zero2:
+labgrid-wigyori-olimex_a20-olinuxino-micro:
   location: wigyorilab
   USBSerialPort:
     match:
       ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.2:1.0
     speed: 115200
   TFTPProvider:
-    internal: "/tftpboot/xunlong_orangepi-zero2"
-    external: "xunlong_orangepi-zero2
+    internal: "/tftpboot/olimex_a20-olinuxino-micro"
+    external: "olimex_a20-olinuxino-micro"
     external_ip: 192.168.102.1
   NetworkService:
     address: "192.168.1.1%eth0.202"
@@ -33,3 +33,68 @@ labgrid-wigyori-xunlong_orangepi-zero2:
     match:
       ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:2:1.0
     index: 2
+
+labgrid-wigyori-xunlong_orangepi-2:
+  location: wigyorilab
+  USBSerialPort:
+    match:
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.3:1.0
+    speed: 115200
+  TFTPProvider:
+    internal: "/tftpboot/xunlong_orangepi-2"
+    external: "xunlong_orangepi-2"
+    external_ip: 192.168.103.1
+  NetworkService:
+    address: "192.168.1.1%eth0.203"
+    username: "root"
+  USBPowerPort:
+    match:
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:2:1.0
+    index: 3
+
+labgrid-wigyori-xunlong_orangepi-zero2:
+  location: wigyorilab
+  USBSerialPort:
+    match:
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.4:1.0
+    speed: 115200
+  TFTPProvider:
+    internal: "/tftpboot/xunlong_orangepi-zero2"
+    external: "xunlong_orangepi-zero2"
+    external_ip: 192.168.104.1
+  NetworkService:
+    address: "192.168.1.1%eth0.204"
+    username: "root"
+  USBPowerPort:
+    match:
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:2:1.0
+    index: 4
+
+labgrid-wigyori-linksprite_a10-pcduino:
+  location: wigyorilab
+  USBSerialPort:
+    match:
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3.1:1.0
+    speed: 115200
+  TFTPProvider:
+    internal: "/tftpboot/linksprite_a10-pcduino"
+    external: "linksprite_a10-pcduino"
+    external_ip: 192.168.105.1
+  NetworkService:
+    address: "192.168.1.1%eth0.205"
+    username: "root"
+
+labgrid-wigyori-pine64_pine64-plus:
+  location: wigyorilab
+  USBSerialPort:
+    match:
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3.2:1.0
+    speed: 115200
+  TFTPProvider:
+    internal: "/tftpboot/pine64_pine64-plus"
+    external: "pine64_pine64-plus"
+    external_ip: 192.168.106.1
+  NetworkService:
+    address: "192.168.1.1%eth0.206"
+    username: "root"
+

--- a/docs/labs/wigyorilab.md
+++ b/docs/labs/wigyorilab.md
@@ -4,30 +4,40 @@
 - Raspberry Pi 4
     - Ethernet (eth0): Uplink in untagged VLAN
     - VLAN201-206: VLANs for DUTs
-    - Serial consoles: 4-port USB hub with various cp2102/pl2303
+    - Serial consoles: 2x 4-port USB hub with various cp2102/pl2303
     - UUGear 4-port switchable USB3 hub
     - ClusterHat 4-port switchable hat via i2c (clusterctrl)
 
 ## DUTs
-- Pine64 (cortexa53)
+- Olimex A10 Lime
     - LAN-port: connected into vlan201
     - Serial: USB hub port 1
     - Power: UUGear port 1
 
-- Orange Pi Zero2 (cortexa53)
+- Olimex A20 Micro
     - LAN-port: connected into vlan202
     - Serial: USB hub port 2
     - Power: UUGear port 2
 
-- Orange Pi 2 (cortexa7)
+- Orange Pi Zero2 (cortexa53)
     - LAN-port: connected into vlan203
     - Serial: USB hub port 3
     - Power: UUGear port 3
 
-- Linksprite pcDuino 2 (cortexa8)
+- Orange Pi 2 (cortexa7)
     - LAN-port: connected into vlan204
     - Serial: USB hub port 4
     - Power: UUGear port 4
+
+- Linksprite pcDuino 2 (cortexa8)
+    - LAN-port: connected into vlan205
+    - Serial: 2nd USB hub port 1
+    - Power: clusterHAT port 1
+
+- Pine64 Plus (cortexa53)
+    - LAN-port: connected into vlan206
+    - Serial: 2nd USB hub port 2
+    - Power: clusterHAT port 2
 
 ## Misc Hardware / Notes
 

--- a/labnet.yaml
+++ b/labnet.yaml
@@ -39,9 +39,33 @@ devices:
     target: mvebu-cortexa9
     firmware: initramfs-kernel.bin
 
+  olimex_a10-lime:
+    name: Olimex A10 Lime
+    target: sunxi-cortexa8
+    firmware: initramfs-kernel.bin
+    snapshots_only: true
+
+  olimex_a20-olinuxino-micro:
+    name: Olimex A20 Micro
+    target: sunxi-cortexa7
+    firmware: initramfs-kernel.bin
+    snapshots_only: true
+
   xunlong_orangepi-zero2:
     name: Orange Pi Zero2
     target: sunxi-cortexa53
+    firmware: initramfs-kernel.bin
+    snapshots_only: true
+
+  xunlong_orangepi-2:
+    name: Orange Pi 2
+    target: sunxi-cortexa7
+    firmware: initramfs-kernel.bin
+    snapshots_only: true
+
+  linksprite_a10-pcduino:
+    name: Linksprite pcDuino 2
+    target: sunxi-cortexa8
     firmware: initramfs-kernel.bin
     snapshots_only: true
 
@@ -144,7 +168,9 @@ labs:
     proxy: labgrid-wigyori
     maintainers: "@wigyori"
     devices:
-      - pine64_pine64-plus
+      - olimex_a10-olinuxino-lime
+      - olimex_a20-olinuxino-micro
+      - xunlong_orangepi-2
       - xunlong_orangepi-zero2
     developers:
       - wigyori

--- a/targets/linksprite_a10-pcduino.yaml
+++ b/targets/linksprite_a10-pcduino.yaml
@@ -1,0 +1,34 @@
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: !template "$LG_PLACE"
+    drivers:
+      USBPowerDriver: {}
+      TFTPProviderDriver: {}
+      SerialDriver:
+        txdelay: 0.05
+      UBootDriver:
+        interrupt: "\n"
+        prompt: "=>"
+        init_commands:
+          - setenv bootargs 'earlyprintk console=ttyS0,115200'
+          - tftp $ramdisk_addr_r
+        boot_command: bootm $ramdisk_addr_r
+      ShellDriver:
+        prompt: 'root@[\w()]+:[^ ]+ '
+        login_prompt: Please press Enter to activate this console.
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+        username: root
+      UBootTFTPStrategy: {}
+      SSHDriver:
+        connection_timeout: 120.0
+        explicit_scp_mode: True
+
+images:
+  root: !template $LG_IMAGE
+
+imports:
+  - ../strategies/tftpstrategy.py

--- a/targets/olimex_a10-olinuxino-lime.yaml
+++ b/targets/olimex_a10-olinuxino-lime.yaml
@@ -1,0 +1,34 @@
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: !template "$LG_PLACE"
+    drivers:
+      USBPowerDriver: {}
+      TFTPProviderDriver: {}
+      SerialDriver:
+        txdelay: 0.05
+      UBootDriver:
+        interrupt: "\n"
+        prompt: "=>"
+        init_commands:
+          - setenv bootargs 'earlyprintk console=ttyS0,115200'
+          - tftp $ramdisk_addr_r
+        boot_command: bootm $ramdisk_addr_r
+      ShellDriver:
+        prompt: 'root@[\w()]+:[^ ]+ '
+        login_prompt: Please press Enter to activate this console.
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+        username: root
+      UBootTFTPStrategy: {}
+      SSHDriver:
+        connection_timeout: 120.0
+        explicit_scp_mode: True
+
+images:
+  root: !template $LG_IMAGE
+
+imports:
+  - ../strategies/tftpstrategy.py

--- a/targets/olimex_a20-olinuxino-micro.yaml
+++ b/targets/olimex_a20-olinuxino-micro.yaml
@@ -1,0 +1,34 @@
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: !template "$LG_PLACE"
+    drivers:
+      USBPowerDriver: {}
+      TFTPProviderDriver: {}
+      SerialDriver:
+        txdelay: 0.05
+      UBootDriver:
+        interrupt: "\n"
+        prompt: "=>"
+        init_commands:
+          - setenv bootargs 'earlyprintk console=ttyS0,115200'
+          - tftp $ramdisk_addr_r
+        boot_command: bootm $ramdisk_addr_r
+      ShellDriver:
+        prompt: 'root@[\w()]+:[^ ]+ '
+        login_prompt: Please press Enter to activate this console.
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+        username: root
+      UBootTFTPStrategy: {}
+      SSHDriver:
+        connection_timeout: 120.0
+        explicit_scp_mode: True
+
+images:
+  root: !template $LG_IMAGE
+
+imports:
+  - ../strategies/tftpstrategy.py

--- a/targets/xunlong_orangepi-2.yaml
+++ b/targets/xunlong_orangepi-2.yaml
@@ -1,0 +1,34 @@
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: !template "$LG_PLACE"
+    drivers:
+      USBPowerDriver: {}
+      TFTPProviderDriver: {}
+      SerialDriver:
+        txdelay: 0.05
+      UBootDriver:
+        interrupt: "\n"
+        prompt: "=>"
+        init_commands:
+          - setenv bootargs 'earlyprintk console=ttyS0,115200'
+          - tftp $ramdisk_addr_r
+        boot_command: bootm $ramdisk_addr_r
+      ShellDriver:
+        prompt: 'root@[\w()]+:[^ ]+ '
+        login_prompt: Please press Enter to activate this console.
+        await_login_timeout: 15
+        login_timeout: 120
+        post_login_settle_time: 5
+        username: root
+      UBootTFTPStrategy: {}
+      SSHDriver:
+        connection_timeout: 120.0
+        explicit_scp_mode: True
+
+images:
+  root: !template $LG_IMAGE
+
+imports:
+  - ../strategies/tftpstrategy.py


### PR DESCRIPTION
 - Add 2 new devices hooked to the controllable usb hub
 - Add definitions for 2 devices hooked to the clusterctrl
 - Update tftpboot directories
 - Update serial console targets according to the re-wiring