### PR TITLE
labnet: wigyori: replace USB hubs hosting the serial consoles

### DIFF
--- a/ansible/files/exporter/labgrid-wigyori.yaml
+++ b/ansible/files/exporter/labgrid-wigyori.yaml
@@ -2,7 +2,7 @@ labgrid-wigyori-olimex_a10-olinuxino-lime:
   location: wigyorilab
   USBSerialPort:
     match:
-      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.1:1.0
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.4:1.0
     speed: 115200
   TFTPProvider:
     internal: "/tftpboot/olimex_a10-olinuxino-lime"
@@ -20,7 +20,7 @@ labgrid-wigyori-olimex_a20-olinuxino-micro:
   location: wigyorilab
   USBSerialPort:
     match:
-      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.2:1.0
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.3:1.0
     speed: 115200
   TFTPProvider:
     internal: "/tftpboot/olimex_a20-olinuxino-micro"
@@ -38,7 +38,7 @@ labgrid-wigyori-xunlong_orangepi-2:
   location: wigyorilab
   USBSerialPort:
     match:
-      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.3:1.0
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.2:1.0
     speed: 115200
   TFTPProvider:
     internal: "/tftpboot/xunlong_orangepi-2"
@@ -56,7 +56,7 @@ labgrid-wigyori-xunlong_orangepi-zero2:
   location: wigyorilab
   USBSerialPort:
     match:
-      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.4:1.0
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.1:1.0
     speed: 115200
   TFTPProvider:
     internal: "/tftpboot/xunlong_orangepi-zero2"
@@ -74,7 +74,7 @@ labgrid-wigyori-linksprite_a10-pcduino:
   location: wigyorilab
   USBSerialPort:
     match:
-      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3.1:1.0
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.7.4:1.0
     speed: 115200
   TFTPProvider:
     internal: "/tftpboot/linksprite_a10-pcduino"
@@ -92,7 +92,7 @@ labgrid-wigyori-pine64_pine64-plus:
   location: wigyorilab
   USBSerialPort:
     match:
-      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.3.2:1.0
+      ID_PATH: platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4.7.3:1.0
     speed: 115200
   TFTPProvider:
     internal: "/tftpboot/pine64_pine64-plus"


### PR DESCRIPTION
Replace the el-cheapo USB hubs with a proper Plugable 10-port.