### PR TITLE
ci: resolve firmware via profiles.json

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -89,20 +89,33 @@ jobs:
             ) | flatten
           ')
 
-          # Combine devices with versions to create full matrix
+          # Combine devices with versions; skip snapshots_only devices for non-snapshot versions
           matrix=$(echo "$device_matrix" | jq --argjson versions "$versions" '
-            [.[] as $device | $versions[] as $version | $device + {"version_url": $version.version_url, "version_name": $version.name}]
+            [ .[] as $device | $versions[] as $version |
+              select($version.name == "snapshot" or $device.snapshots_only != true) |
+              $device + {"version_url": $version.version_url, "version_name": $version.name} ]
           ')
           echo "matrix=$(echo "$matrix" | jq -c '.')" >> $GITHUB_ENV
 
-          # Create QEMU matrix
-          qemu_base='[
-            {"target": "malta-be", "dependency": "qemu-system-mips"},
-            {"target": "x86-64", "dependency": "qemu-system-x86"},
-            {"target": "armsr-armv8", "dependency": "qemu-system-aarch64"}
-          ]'
+          # Build QEMU matrix from targets/qemu_*.yaml (dependency is per-target apt package)
+          qemu_base=$(
+            for f in targets/qemu_*.yaml; do
+              target=${f##*/qemu_}; target=${target%.yaml}
+              so=$(yq -r '.openwrt.snapshots_only // false' "$f")
+              case "$target" in
+                malta-be) dep=qemu-system-mips ;;
+                x86-64) dep=qemu-system-x86 ;;
+                armsr-armv8) dep=qemu-system-aarch64 ;;
+                *) continue ;;
+              esac
+              jq -n --arg t "$target" --arg d "$dep" --argjson so "$so" \
+                '{target: $t, dependency: $d, snapshots_only: $so}'
+            done | jq -s '.'
+          )
           qemu_matrix=$(echo "$qemu_base" | jq --argjson versions "$versions" '
-            [.[] as $qemu | $versions[] as $version | $qemu + {"version_url": $version.version_url, "version_name": $version.name}]
+            [ .[] as $qemu | $versions[] as $version |
+              select($version.name == "snapshot" or $qemu.snapshots_only != true) |
+              ($qemu + {"version_url": $version.version_url, "version_name": $version.name} | del(.snapshots_only)) ]
           ')
           echo "qemu_matrix=$(echo "$qemu_matrix" | jq -c '.')" >> $GITHUB_ENV
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -60,30 +60,34 @@ jobs:
             ]"
           fi
 
-          device_matrix=$(yq -o=json '
-            . as $root |
-            $root.labs as $labs |
-            $root.devices as $devices |
-            $labs
-            | to_entries
-            | map(
-                .key as $lab |
-                .value.devices
-                | map(
-                    select($devices[.] != null) |
-                    {
-                      "device": .,
-                      "name": $devices[.].name,
-                      "proxy": $labs[$lab].proxy,
-                      "target": $devices[.].target,
-                      "firmware": $devices[.].firmware,
-                      "maintainers": $labs[$lab].maintainers,
-                      "snapshots_only": ($devices[.].snapshots_only // false)
-                    }
-                  )
+          # Collect device metadata from targets/*.yaml
+          devices_meta=$(
+            for f in targets/*.yaml; do
+              head -1 "$f" | grep -q '^openwrt:' || continue
+              device=$(basename "$f" .yaml)
+              name=$(yq -r '.openwrt.name' "$f")
+              so=$(yq -r '.openwrt.snapshots_only // false' "$f")
+              jq -n --arg d "$device" --arg n "$name" --argjson so "$so" \
+                '{($d): {name: $n, snapshots_only: $so}}'
+            done | jq -s 'add'
+          )
+
+          device_matrix=$(yq -o=json labnet.yaml | jq --argjson devices "$devices_meta" '
+            .labs as $labs |
+            ($labs | to_entries) | map(
+              .key as $lab |
+              $labs[$lab].devices | map(
+                select($devices[.] != null) |
+                {
+                  "device": .,
+                  "name": $devices[.].name,
+                  "proxy": $labs[$lab].proxy,
+                  "maintainers": $labs[$lab].maintainers,
+                  "snapshots_only": $devices[.].snapshots_only
+                }
               )
-            | flatten
-          ' labnet.yaml)
+            ) | flatten
+          ')
 
           # Combine devices with versions to create full matrix
           matrix=$(echo "$device_matrix" | jq --argjson versions "$versions" '
@@ -93,9 +97,9 @@ jobs:
 
           # Create QEMU matrix
           qemu_base='[
-            {"target": "malta-be", "firmware": "vmlinux-initramfs.elf", "dependency": "qemu-system-mips"},
-            {"target": "x86-64", "firmware": "generic-squashfs-combined.img.gz", "dependency": "qemu-system-x86"},
-            {"target": "armsr-armv8", "firmware": "generic-initramfs-kernel.bin", "dependency": "qemu-system-aarch64"}
+            {"target": "malta-be", "dependency": "qemu-system-mips"},
+            {"target": "x86-64", "dependency": "qemu-system-x86"},
+            {"target": "armsr-armv8", "dependency": "qemu-system-aarch64"}
           ]'
           qemu_matrix=$(echo "$qemu_base" | jq --argjson versions "$versions" '
             [.[] as $qemu | $versions[] as $version | $qemu + {"version_url": $version.version_url, "version_name": $version.name}]
@@ -177,117 +181,53 @@ jobs:
 
       - name: Set environment
         env:
-          target: ${{ matrix.target }}
           VERSION_NAME: ${{ matrix.version_name }}
           UPSTREAM_URL: ${{ matrix.version_url }}
+          DEVICE: ${{ matrix.device }}
         run: |
-          if [ "$VERSION_NAME" = "snapshot" ]; then
-            # Define labgrid features
-            echo "LG_FEATURE_APK=true" >> $GITHUB_ENV
+          target=$(yq -r '.openwrt.target' targets/$DEVICE.yaml)
+          profile=$(yq -r '.openwrt.profile' targets/$DEVICE.yaml)
+          image_type=$(yq -r '.openwrt.image.type // "kernel"' targets/$DEVICE.yaml)
+          image_fs=$(yq -r '.openwrt.image.filesystem // ""' targets/$DEVICE.yaml)
 
-            # Snapshot logic (existing)
-            export firmware=openwrt-${{ matrix.target }}-${{ matrix.device }}-${{ matrix.firmware }}
-
-            mkdir -p $GITHUB_WORKSPACE/tftp/${{ matrix.device }}
-            if ! wget $UPSTREAM_URL/${target/-/\/}/$firmware \
-              --output-document $GITHUB_WORKSPACE/tftp/${{ matrix.device }}/$firmware; then
-              echo "::warning::Failed to download firmware $firmware. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-            (cd $GITHUB_WORKSPACE/tftp/ && gzip -df ${{ matrix.device }}/$firmware) || true
-
-            FIRMWARE_VERSION=$(curl $UPSTREAM_URL/${target/-/\/}/version.buildinfo)
-            echo "FIRMWARE_VERSION=$FIRMWARE_VERSION" >> $GITHUB_ENV
-            echo "LG_IMAGE=$GITHUB_WORKSPACE/tftp/${{ matrix.device }}/${firmware/.gz/}" >> $GITHUB_ENV
-          else
-            # Stable release logic
-
-            # Fetch profiles.json to get real firmware filename
-            profiles_url="$UPSTREAM_URL/${target/-/\/}/profiles.json"
-            profiles_json=$(curl -s "$profiles_url")
-
-            # Check if profiles.json was successfully downloaded
-            if [ -z "$profiles_json" ] || [ "$profiles_json" = "{}" ] || ! echo "$profiles_json" | jq empty 2>/dev/null; then
-              echo "::warning::Could not download or parse profiles.json from $profiles_url. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-
-            # Find the kernel image for the device
-            if [ "${{ matrix.device }}" = "generic" ]; then
-              profile_key="generic"
-            else
-              # For non-generic devices, we might need to search through profiles
-              profile_key="${{ matrix.device }}"
-            fi
-
-            # Check if the profile exists in profiles.json
-            profile_exists=$(echo "$profiles_json" | jq -r --arg profile "$profile_key" '.profiles | has($profile)')
-            if [ "$profile_exists" != "true" ]; then
-              echo "::warning::Profile '$profile_key' not found in profiles.json. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-
-            # Extract the kernel/combined image filename based on firmware type
-            case "${{ matrix.firmware }}" in
-              *squashfs-combined*)
-                image_type="combined"
-                filesystem="squashfs"
-                ;;
-              *ext4-combined*)
-                image_type="combined"
-                filesystem="ext4"
-                ;;
-              *initramfs*)
-                image_type="kernel"
-                filesystem=""
-                ;;
-              *vmlinux*)
-                image_type="kernel"
-                filesystem=""
-                ;;
-              *)
-                image_type="combined"
-                filesystem="squashfs"
-                ;;
-            esac
-
-            if [ -n "$filesystem" ]; then
-              firmware_filename=$(echo "$profiles_json" | jq -r --arg profile "$profile_key" --arg type "$image_type" --arg fs "$filesystem" '
-                .profiles[$profile].images[] | select(.type == $type and .filesystem == $fs) | .name
-              ')
-            else
-              firmware_filename=$(echo "$profiles_json" | jq -r --arg profile "$profile_key" --arg type "$image_type" '
-                .profiles[$profile].images[] | select(.type == $type) | .name
-              ')
-            fi
-
-            if [ -z "$firmware_filename" ] || [ "$firmware_filename" = "null" ]; then
-              echo "Could not find firmware filename for device ${{ matrix.device }}, falling back to constructed name"
-              # Fallback to constructed filename
-              image_prefix=$(echo "$profiles_json" | jq -r --arg profile "$profile_key" '.profiles[$profile].image_prefix')
-              firmware_filename="$image_prefix-${{ matrix.firmware }}"
-            fi
-
-            echo "Using firmware: $firmware_filename"
-
-            mkdir -p $GITHUB_WORKSPACE/tftp/${{ matrix.device }}
-            if ! wget "$UPSTREAM_URL/${target/-/\/}/$firmware_filename" \
-              --output-document $GITHUB_WORKSPACE/tftp/${{ matrix.device }}/$firmware_filename; then
-              echo "::warning::Failed to download firmware $firmware_filename. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-            (cd $GITHUB_WORKSPACE/tftp/ && gzip -df ${{ matrix.device }}/$firmware_filename) || true
-
-            FIRMWARE_VERSION=$(echo "$profiles_json" | jq -r '.version_code')
-            echo "FIRMWARE_VERSION=$FIRMWARE_VERSION" >> $GITHUB_ENV
-            echo "LG_IMAGE=$GITHUB_WORKSPACE/tftp/${{ matrix.device }}/${firmware_filename/.gz/}" >> $GITHUB_ENV
+          profiles_url="$UPSTREAM_URL/${target/-/\/}/profiles.json"
+          profiles_json=$(curl -sf "$profiles_url") || profiles_json=""
+          if [ -z "$profiles_json" ] || ! echo "$profiles_json" | jq empty 2>/dev/null; then
+            echo "::warning::Could not fetch $profiles_url. Skipping."
+            echo "SKIP_TEST=true" >> $GITHUB_ENV
+            exit 0
           fi
 
+          if [ -n "$image_fs" ]; then
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" --arg fs "$image_fs" \
+              '.profiles[$p].images[]? | select(.type == $t and .filesystem == $fs) | .name' | head -n1)
+          else
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" \
+              '.profiles[$p].images[]? | select(.type == $t) | .name' | head -n1)
+          fi
+
+          if [ -z "$firmware_name" ]; then
+            echo "::warning::No image type=$image_type fs=$image_fs for profile $profile. Skipping."
+            echo "SKIP_TEST=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          mkdir -p $GITHUB_WORKSPACE/tftp/$DEVICE
+          if ! wget -q "$UPSTREAM_URL/${target/-/\/}/$firmware_name" \
+            --output-document "$GITHUB_WORKSPACE/tftp/$DEVICE/$firmware_name"; then
+            echo "::warning::Failed to download $firmware_name. Skipping."
+            echo "SKIP_TEST=true" >> $GITHUB_ENV
+            exit 0
+          fi
+          (cd $GITHUB_WORKSPACE/tftp/ && gzip -df $DEVICE/$firmware_name) || true
+
+          FIRMWARE_VERSION=$(echo "$profiles_json" | jq -r '.version_code')
+          echo "FIRMWARE_VERSION=$FIRMWARE_VERSION" >> $GITHUB_ENV
+          echo "LG_IMAGE=$GITHUB_WORKSPACE/tftp/$DEVICE/${firmware_name/.gz/}" >> $GITHUB_ENV
           echo "LG_PROXY=${{ matrix.proxy }}" >> $GITHUB_ENV
+          if [ "$VERSION_NAME" = "snapshot" ]; then
+            echo "LG_FEATURE_APK=true" >> $GITHUB_ENV
+          fi
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -360,95 +300,48 @@ jobs:
 
       - name: Download test firmware
         env:
-          target: ${{ matrix.target }}
           VERSION_NAME: ${{ matrix.version_name }}
           UPSTREAM_URL: ${{ matrix.version_url }}
         run: |
-          if [ "$VERSION_NAME" = "snapshot" ]; then
-            # Define labgrid features
-            echo "LG_FEATURE_APK=true" >> $GITHUB_ENV
+          target=$(yq -r '.openwrt.target' targets/qemu_${{ matrix.target }}.yaml)
+          profile=$(yq -r '.openwrt.profile' targets/qemu_${{ matrix.target }}.yaml)
+          image_type=$(yq -r '.openwrt.image.type // "kernel"' targets/qemu_${{ matrix.target }}.yaml)
+          image_fs=$(yq -r '.openwrt.image.filesystem // ""' targets/qemu_${{ matrix.target }}.yaml)
 
-            # Snapshot logic
-            firmware_name="openwrt-$target-${{ matrix.firmware }}"
-            if ! wget "$UPSTREAM_URL/${target/-/\/}/$firmware_name" \
-              --output-document "$firmware_name"; then
-              echo "::warning::Failed to download firmware $firmware_name. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-            FIRMWARE_VERSION=$(curl "$UPSTREAM_URL/${target/-/\/}/version.buildinfo")
-          else
-            # Stable release logic
-            profiles_url="$UPSTREAM_URL/${target/-/\/}/profiles.json"
-            profiles_json=$(curl -s "$profiles_url")
-
-            # Check if profiles.json was successfully downloaded
-            if [ -z "$profiles_json" ] || [ "$profiles_json" = "{}" ] || ! echo "$profiles_json" | jq empty 2>/dev/null; then
-              echo "::warning::Could not download or parse profiles.json from $profiles_url. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-
-            # Check if the generic profile exists in profiles.json
-            profile_exists=$(echo "$profiles_json" | jq -r '.profiles | has("generic")')
-            if [ "$profile_exists" != "true" ]; then
-              echo "::warning::Profile 'generic' not found in profiles.json. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-
-            # Find the appropriate image for QEMU
-            case "${{ matrix.firmware }}" in
-              *squashfs-combined*)
-                image_type="combined"
-                filesystem="squashfs"
-                ;;
-              *ext4-combined*)
-                image_type="combined"
-                filesystem="ext4"
-                ;;
-              *initramfs*)
-                image_type="kernel"
-                filesystem=""
-                ;;
-              *vmlinux*)
-                image_type="kernel"
-                filesystem=""
-                ;;
-              *)
-                image_type="combined"
-                filesystem="squashfs"
-                ;;
-            esac
-
-            if [ -n "$filesystem" ]; then
-              firmware_name=$(echo "$profiles_json" | jq -r --arg type "$image_type" --arg fs "$filesystem" '
-                .profiles.generic.images[] | select(.type == $type and .filesystem == $fs) | .name
-              ')
-            else
-              firmware_name=$(echo "$profiles_json" | jq -r --arg type "$image_type" '
-                .profiles.generic.images[] | select(.type == $type) | .name
-              ')
-            fi
-
-            if [ -z "$firmware_name" ] || [ "$firmware_name" = "null" ]; then
-              echo "Could not find firmware, falling back to constructed name"
-              image_prefix=$(echo "$profiles_json" | jq -r '.profiles.generic.image_prefix')
-              firmware_name="$image_prefix-${{ matrix.firmware }}"
-            fi
-
-            echo "Using firmware: $firmware_name"
-            if ! wget "$UPSTREAM_URL/${target/-/\/}/$firmware_name" \
-              --output-document "$firmware_name"; then
-              echo "::warning::Failed to download firmware $firmware_name. Skipping CI test."
-              echo "SKIP_TEST=true" >> $GITHUB_ENV
-              exit 0
-            fi
-            FIRMWARE_VERSION=$(echo "$profiles_json" | jq -r '.version_code')
+          profiles_url="$UPSTREAM_URL/${target/-/\/}/profiles.json"
+          profiles_json=$(curl -sf "$profiles_url") || profiles_json=""
+          if [ -z "$profiles_json" ] || ! echo "$profiles_json" | jq empty 2>/dev/null; then
+            echo "::warning::Could not fetch $profiles_url. Skipping."
+            echo "SKIP_TEST=true" >> $GITHUB_ENV
+            exit 0
           fi
 
+          if [ -n "$image_fs" ]; then
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" --arg fs "$image_fs" \
+              '.profiles[$p].images[]? | select(.type == $t and .filesystem == $fs) | .name' | head -n1)
+          else
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" \
+              '.profiles[$p].images[]? | select(.type == $t) | .name' | head -n1)
+          fi
+
+          if [ -z "$firmware_name" ]; then
+            echo "::warning::No image type=$image_type fs=$image_fs for profile $profile. Skipping."
+            echo "SKIP_TEST=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          if ! wget -q "$UPSTREAM_URL/${target/-/\/}/$firmware_name" --output-document "$firmware_name"; then
+            echo "::warning::Failed to download $firmware_name. Skipping."
+            echo "SKIP_TEST=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          FIRMWARE_VERSION=$(echo "$profiles_json" | jq -r '.version_code')
           echo "FIRMWARE_VERSION=$FIRMWARE_VERSION" >> $GITHUB_ENV
           echo "FIRMWARE_FILE=$firmware_name" >> $GITHUB_ENV
+          if [ "$VERSION_NAME" = "snapshot" ]; then
+            echo "LG_FEATURE_APK=true" >> $GITHUB_ENV
+          fi
 
       - name: Skip test notification
         if: env.SKIP_TEST == 'true'

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -30,28 +30,29 @@ jobs:
 
           # Use pipe because of this bug
           # https://github.com/mikefarah/yq/issues/2454
-          matrix=$(yq -o=json labnet.yaml | jq '
-            . as $root |
-            $root.labs as $labs |
-            $root.devices as $devices |
-            $labs
-            | to_entries
-            | map(
-                .key as $lab |
-                .value.devices
-                | map(
-                    select($devices[.] != null and $devices[.].snapshots_only != true) |
-                    {
-                      "device": .,
-                      "proxy": $labs[$lab].proxy,
-                      "target": $devices[.].target,
-                      "firmware": $devices[.].firmware,
-                      "maintainers": $labs[$lab].maintainers,
-                      "snapshots_only": ($devices[.].snapshots_only // false)
-                    }
-                  )
+          devices_meta=$(
+            for f in targets/*.yaml; do
+              head -1 "$f" | grep -q '^openwrt:' || continue
+              device=$(basename "$f" .yaml)
+              so=$(yq -r '.openwrt.snapshots_only // false' "$f")
+              jq -n --arg d "$device" --argjson so "$so" '{($d): {snapshots_only: $so}}'
+            done | jq -s 'add'
+          )
+
+          matrix=$(yq -o=json labnet.yaml | jq --argjson devices "$devices_meta" '
+            .labs as $labs |
+            ($labs | to_entries) | map(
+              .key as $lab |
+              $labs[$lab].devices | map(
+                select($devices[.] != null and $devices[.].snapshots_only != true) |
+                {
+                  "device": .,
+                  "proxy": $labs[$lab].proxy,
+                  "maintainers": $labs[$lab].maintainers,
+                  "snapshots_only": $devices[.].snapshots_only
+                }
               )
-            | flatten
+            ) | flatten
           ')
           echo "matrix=$(echo "$matrix" | jq -c '.')" >> $GITHUB_OUTPUT
 
@@ -99,26 +100,38 @@ jobs:
 
       - name: Set environment
         env:
-          target: ${{ matrix.target }}
+          DEVICE: ${{ matrix.device }}
         run: |
           # workaround until 24.10.x is fixed on tplink_tl-wr1043nd-v3
-          if [ "${{ matrix.device }}" = "tplink_tl-wr1043nd-v3" ]; then
+          if [ "$DEVICE" = "tplink_tl-wr1043nd-v3" ]; then
             export RELEASE=23.05.5
             echo "RELEASE=${RELEASE}" >> $GITHUB_ENV
           fi
 
-          export firmware=openwrt-${RELEASE}-${{ matrix.target }}-${{ matrix.device }}-${{ matrix.firmware }}
-          export upstream_url="https://mirror-03.infra.openwrt.org/releases/${RELEASE}/targets"
+          target=$(yq -r '.openwrt.target' targets/$DEVICE.yaml)
+          profile=$(yq -r '.openwrt.profile' targets/$DEVICE.yaml)
+          image_type=$(yq -r '.openwrt.image.type // "kernel"' targets/$DEVICE.yaml)
+          image_fs=$(yq -r '.openwrt.image.filesystem // ""' targets/$DEVICE.yaml)
 
-          mkdir -p $GITHUB_WORKSPACE/tftp/${{ matrix.device }}
-          wget $upstream_url/${target/-/\/}/$firmware \
-            --output-document $GITHUB_WORKSPACE/tftp/${{ matrix.device }}/$firmware
-            (cd $GITHUB_WORKSPACE/tftp/ && gzip -d ${{ matrix.device }}/$firmware) || true
+          upstream_url="https://mirror-03.infra.openwrt.org/releases/${RELEASE}/targets"
+          profiles_json=$(curl -sf "$upstream_url/${target/-/\/}/profiles.json")
 
-          FIRMWARE_VERSION=$(curl $upstream_url/${target/-/\/}/version.buildinfo)
+          if [ -n "$image_fs" ]; then
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" --arg fs "$image_fs" \
+              '.profiles[$p].images[]? | select(.type == $t and .filesystem == $fs) | .name' | head -n1)
+          else
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" \
+              '.profiles[$p].images[]? | select(.type == $t) | .name' | head -n1)
+          fi
+
+          mkdir -p $GITHUB_WORKSPACE/tftp/$DEVICE
+          wget -q "$upstream_url/${target/-/\/}/$firmware_name" \
+            --output-document "$GITHUB_WORKSPACE/tftp/$DEVICE/$firmware_name"
+          (cd $GITHUB_WORKSPACE/tftp/ && gzip -df $DEVICE/$firmware_name) || true
+
+          FIRMWARE_VERSION=$(echo "$profiles_json" | jq -r '.version_code')
           echo "FIRMWARE_VERSION=$FIRMWARE_VERSION" >> $GITHUB_ENV
-
-          echo "LG_IMAGE=$GITHUB_WORKSPACE/tftp/${{ matrix.device }}/${firmware/.gz/}" >> $GITHUB_ENV
+          echo "LG_IMAGE=$GITHUB_WORKSPACE/tftp/$DEVICE/${firmware_name/.gz/}" >> $GITHUB_ENV
           echo "LG_PROXY=${{ matrix.proxy }}" >> $GITHUB_ENV
 
       - name: Install dependencies

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -7,7 +7,6 @@ env:
   PYTHONUNBUFFERED: "1"
   PYTEST_ADDOPTS: "--color=yes"
   LG_CONSOLE: "internal"
-  RELEASE: "24.10.2"
 
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.ref }}
@@ -37,11 +36,8 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install nmap ${{ matrix.dependency }}
 
-          # workaround until ARMSR is fixed
-          if [ "${{ matrix.target }}" = "armsr-armv8" ]; then
-            echo "RELEASE=23.05.5" >> $GITHUB_ENV
-          fi
-
+          RELEASE=$(curl -s https://downloads.openwrt.org/.versions.json | jq -r '.stable_version')
+          echo "RELEASE=$RELEASE" >> $GITHUB_ENV
           echo "LG_ENV=targets/qemu_${{ matrix.target }}.yaml" >> $GITHUB_ENV
 
       - name: Install uv

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -22,15 +22,10 @@ jobs:
       matrix:
         include:
           - target: malta-be
-            firmware: openwrt-${RELEASE}-malta-be-vmlinux-initramfs.elf
             dependency: qemu-system-mips
-
           - target: x86-64
-            firmware: openwrt-${RELEASE}-x86-64-generic-squashfs-combined.img.gz
             dependency: qemu-system-x86
-
           - target: armsr-armv8
-            firmware: openwrt-${RELEASE}-armsr-armv8-generic-initramfs-kernel.bin
             dependency: qemu-system-aarch64
 
     steps:
@@ -40,41 +35,51 @@ jobs:
       - name: Setup environment
         run: |
           sudo apt-get update
-          sudo apt-get -y install \
-            nmap \
-            ${{ matrix.dependency }}
+          sudo apt-get -y install nmap ${{ matrix.dependency }}
 
           # workaround until ARMSR is fixed
           if [ "${{ matrix.target }}" = "armsr-armv8" ]; then
-            export RELEASE=23.05.5
-            echo "RELEASE=${RELEASE}" >> $GITHUB_ENV
+            echo "RELEASE=23.05.5" >> $GITHUB_ENV
           fi
 
           echo "LG_ENV=targets/qemu_${{ matrix.target }}.yaml" >> $GITHUB_ENV
-          echo "UPSTREAM_URL=https://mirror-03.infra.openwrt.org/releases/${RELEASE}/targets" >> $GITHUB_ENV
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
       - name: Download test firmware
-        env:
-          target: ${{ matrix.target }}
         run: |
-          wget $UPSTREAM_URL/${target/-/\/}/${{ matrix.firmware }} \
-            --output-document ${{ matrix.firmware }}
-          FIRMWARE_VERSION=$(curl $UPSTREAM_URL/${target/-/\/}/version.buildinfo)
+          target=$(yq -r '.openwrt.target' targets/qemu_${{ matrix.target }}.yaml)
+          profile=$(yq -r '.openwrt.profile' targets/qemu_${{ matrix.target }}.yaml)
+          image_type=$(yq -r '.openwrt.image.type // "kernel"' targets/qemu_${{ matrix.target }}.yaml)
+          image_fs=$(yq -r '.openwrt.image.filesystem // ""' targets/qemu_${{ matrix.target }}.yaml)
+
+          upstream_url="https://mirror-03.infra.openwrt.org/releases/${RELEASE}/targets"
+          profiles_json=$(curl -sf "$upstream_url/${target/-/\/}/profiles.json")
+
+          if [ -n "$image_fs" ]; then
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" --arg fs "$image_fs" \
+              '.profiles[$p].images[]? | select(.type == $t and .filesystem == $fs) | .name' | head -n1)
+          else
+            firmware_name=$(echo "$profiles_json" | jq -r --arg p "$profile" --arg t "$image_type" \
+              '.profiles[$p].images[]? | select(.type == $t) | .name' | head -n1)
+          fi
+
+          wget -q "$upstream_url/${target/-/\/}/$firmware_name" --output-document "$firmware_name"
+          FIRMWARE_VERSION=$(echo "$profiles_json" | jq -r '.version_code')
           echo "FIRMWARE_VERSION=$FIRMWARE_VERSION" >> $GITHUB_ENV
+          echo "FIRMWARE_FILE=$firmware_name" >> $GITHUB_ENV
 
       - name: Run test
         run: |
-          gunzip ${{ matrix.firmware }} || true
-          firmware=${{ matrix.firmware }}
+          gunzip $FIRMWARE_FILE || true
+          firmware=${FIRMWARE_FILE/.gz/}
 
           uv run pytest tests/ \
             --lg-log \
             --lg-colored-steps \
             --log-cli-level=CONSOLE \
-            --firmware $GITHUB_WORKSPACE/${firmware/.gz/}
+            --firmware $GITHUB_WORKSPACE/$firmware
 
       - name: Upload console logs
         uses: actions/upload-artifact@v7

--- a/docs/sharing-target-files.md
+++ b/docs/sharing-target-files.md
@@ -5,12 +5,6 @@ When a lab has multiple physical devices of the same model (e.g., three Belkin R
 If this is your situation, you can use the `device_instances` field in `labnet.yaml` to define multiple physical instances sharing a single target file:
 
 ```yaml
-devices:
-  linksys_e8450:
-    name: Linksys E8450 / Belkin RT3200
-    target: mediatek-mt7622
-    firmware: initramfs-kernel.bin
-
 labs:
   labgrid-example:
     proxy: labgrid-example
@@ -24,6 +18,16 @@ labs:
         - router_1
         - router_2
         - router_3
+```
+
+Device metadata (name, OpenWrt target, profile, image selection) lives in the labgrid target file (`targets/linksys_e8450.yaml`):
+
+```yaml
+openwrt:
+  name: Linksys E8450 / Belkin RT3200
+  target: mediatek-mt7622
+  profile: linksys_e8450
+  # image.type defaults to "kernel"; override only for factory / combined images
 ```
 
 This will create three different labgrid places from the same configuration file.

--- a/labnet.yaml
+++ b/labnet.yaml
@@ -1,142 +1,3 @@
-devices:
-  ignitenet_ss-w2-ac2600:
-    name: IgniteNet SunSpot AC Wave2
-    target: ipq806x-generic
-    firmware: initramfs-fit-uImage.itb
-    snapshots_only: true
-
-  genexis_pulse-ex400:
-    name: Genexis Pulse EX400 / Inteno Pulse EX400
-    target: ramips-mt7621
-    firmware: initramfs-kernel.bin
-
-  hpe_msm460:
-    name: Hewlett-Packard MSM460
-    target: mpc85xx-p1020
-    firmware: initramfs-kernel.bin
-
-  openwrt_one:
-    name: OpenWrt One
-    target: mediatek-filogic
-    firmware: initramfs.itb
-
-  tplink_tl-wdr3600-v1:
-    name: TP-Link TL-WDR3600 v1
-    target: ath79-generic
-    firmware: initramfs-kernel.bin
-
-  tplink_tl-wdr4300-v1:
-    name: TP-Link TL-WDR4300 v1
-    target: ath79-generic
-    firmware: initramfs-kernel.bin
-
-  tplink_tl-wr842n-v3:
-    name: TP-Link TL-WR842N v3
-    target: ath79-generic
-    firmware: initramfs-kernel.bin
-
-  tplink_tl-wr1043nd-v3:
-    name: TP-Link TL-WR1043N/ND v3
-    target: ath79-generic
-    firmware: initramfs-kernel.bin
-
-  tplink_tl-wr1043nd-v4:
-    name: TP-Link TL-WR1043N/ND v4
-    target: ath79-generic
-    firmware: initramfs-kernel.bin
-
-  cznic_turris-omnia:
-    name: CZ.NIC Turris Omnia
-    target: mvebu-cortexa9
-    firmware: initramfs-kernel.bin
-
-  olimex_a10-olinuxino-lime:
-    name: Olimex A10 Lime
-    target: sunxi-cortexa8
-    firmware: initramfs-kernel.bin
-    snapshots_only: true
-
-  olimex_a20-olinuxino-micro:
-    name: Olimex A20 Micro
-    target: sunxi-cortexa7
-    firmware: initramfs-kernel.bin
-    snapshots_only: true
-
-  xunlong_orangepi-zero2:
-    name: Orange Pi Zero2
-    target: sunxi-cortexa53
-    firmware: initramfs-kernel.bin
-    snapshots_only: true
-
-  xunlong_orangepi-2:
-    name: Orange Pi 2
-    target: sunxi-cortexa7
-    firmware: initramfs-kernel.bin
-    snapshots_only: true
-
-  linksprite_a10-pcduino:
-    name: Linksprite pcDuino 2
-    target: sunxi-cortexa8
-    firmware: initramfs-kernel.bin
-    snapshots_only: true
-
-  pine64_pine64-plus:
-    name: Pine64 Plus
-    target: sunxi-cortexa53
-    firmware: initramfs-kernel.bin
-    snapshots_only: true
-
-  bananapi_bpi-r4:
-    name: Bananapi BPi-R4
-    target: mediatek-filogic
-    firmware: initramfs-recovery.itb
-
-  bananapi_bpi-r4-lite:
-    name: Bananapi BPi-R4 Lite
-    target: mediatek-filogic
-    firmware: initramfs-recovery.itb
-    snapshots_only: true
-
-  bananapi_bpi-r64:
-    name: Bananapi BPi-R64
-    target: mediatek-mt7622
-    firmware: initramfs-recovery.itb
-
-  glinet_gl-mt1300:
-    name: GL.iNet GL-MT1300
-    target: ramips-mt7621
-    firmware: initramfs-kernel.bin
-
-  glinet_gl-mt6000:
-    name: GL.iNet GL-MT6000
-    target: mediatek-filogic
-    firmware: initramfs-kernel.bin
-
-  rpi-4:
-    name: Raspberry Pi 4B/400/CM4 (64bit)
-    target: bcm27xx-bcm2711
-    firmware: squashfs-factory.img.gz
-
-  enterasys_ws-ap3710i:
-    name: Enterasys WS-AP3710i
-    target: mpc85xx-p1020
-    firmware: initramfs-kernel.bin
-
-  iei_puzzle-m902:
-    name: iEi Puzzle-M902
-    target: mvebu-cortexa72
-    firmware: initramfs-kernel.bin
-
-  linksys_e8450:
-    name: Linksys E8450 / Belkin RT3200
-    target: mediatek-mt7622
-    firmware: initramfs-kernel.bin
-
-  librerouter_librerouter-v1:
-    name: LibreRouter v1
-    target: ath79-generic
-    firmware: initramfs-kernel.bin
-
 labs:
   labgrid-aparcar:
     proxy: labgrid-aparcar
@@ -157,7 +18,6 @@ labs:
       - aparcar
       - dangowrt
       - jonasjelonek
-
   labgrid-bastian:
     proxy: labgrid-bastian
     hostkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGxdB8NmJRjrS9lztZDKld8OprqY5ELjZ7koQ3b5atLd
@@ -168,7 +28,6 @@ labs:
       - tplink_tl-wdr4300-v1
     developers:
       - aparcar
-
   labgrid-blocktrron:
     proxy: labgrid-blocktrron
     hostkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGLL+T3zunt13cl9ZSZZkc/W+tnvIENEB28x/VoU2QnV
@@ -179,7 +38,6 @@ labs:
       - tplink_tl-wr842n-v3
     developers:
       - aparcar
-
   labgrid-leinelab:
     proxy: labgrid-leinelab
     hostkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILDEM6JDEorz8cURSX7fXOdKsLKMJZQpzccpSEKytjAf
@@ -189,7 +47,6 @@ labs:
       - tplink_tl-wr1043nd-v3
     developers:
       - aparcar
-
   labgrid-hsn:
     proxy: labgrid-hsn
     hostkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP5kAZ/gVDTHp2rOWmybFSf+JFtoQJPH4KFE+lUGKH0c
@@ -205,7 +62,6 @@ labs:
     developers:
       - aparcar
       - jonasjelonek
-
   labgrid-wigyori:
     proxy: labgrid-wigyori
     hostkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINoXHDKDcWBZ5mj2GSiWomYzaqjaElFQiqmqM4c8K8Q3
@@ -220,7 +76,6 @@ labs:
       - xunlong_orangepi-zero2
     developers:
       - wigyori
-
   labgrid-hauke:
     proxy: labgrid-hauke
     hostkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHuOU1Tc2XIpd8B3Oy+Hg1aHYL+L+IznbVvdCJ04wizX
@@ -230,7 +85,6 @@ labs:
       - openwrt_one
     developers:
       - hauke
-
   labgrid-fcefyn:
     proxy: labgrid-fcefyn
     hostkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK0ANF89u6x2DjGv8wEZ6Yc07WjcV7QM4izgy4EwafYo
@@ -253,7 +107,6 @@ labs:
     developers:
       - francoriba
       - aparcar
-
 developers:
   aparcar:
     sshkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDZTxjQ3/KTefKvsPlVBWz+ITD7dGWcOt8/C55ekd2VE

--- a/targets/bananapi_bpi-r4-lite.yaml
+++ b/targets/bananapi_bpi-r4-lite.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: Bananapi BPi-R4 Lite
+  target: mediatek-filogic
+  profile: bananapi_bpi-r4-lite
+  snapshots_only: true
 targets:
   main:
     features:
@@ -27,9 +32,7 @@ targets:
       - SSHDriver:
           connection_timeout: 120.0
           explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/bananapi_bpi-r4.yaml
+++ b/targets/bananapi_bpi-r4.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: Bananapi BPi-R4
+  target: mediatek-filogic
+  profile: bananapi_bpi-r4
 targets:
   main:
     features:
@@ -27,9 +31,7 @@ targets:
       - SSHDriver:
           connection_timeout: 120.0
           explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/bananapi_bpi-r64.yaml
+++ b/targets/bananapi_bpi-r64.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: Bananapi BPi-R64
+  target: mediatek-mt7622
+  profile: bananapi_bpi-r64
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       - SSHDriver:
           connection_timeout: 120.0
           explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/cznic_turris-omnia.yaml
+++ b/targets/cznic_turris-omnia.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: CZ.NIC Turris Omnia
+  target: mvebu-cortexa9
+  profile: cznic_turris-omnia
 targets:
   main:
     features:
@@ -23,16 +27,14 @@ targets:
           - setenv kernel_addr_r 0x2000000
           - setenv bootargs earlyprintk console=ttyS0,115200
         boot_command: >
-          dhcp $kernel_addr_r $bootfile;
-          bootm $kernel_addr_r
+          dhcp $kernel_addr_r $bootfile; bootm $kernel_addr_r
+
       TFTPProviderDriver: {}
       UBootTFTPStrategy: {}
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/enterasys_ws-ap3710i.yaml
+++ b/targets/enterasys_ws-ap3710i.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: Enterasys WS-AP3710i
+  target: mpc85xx-p1020
+  profile: enterasys_ws-ap3710i
 targets:
   main:
     features:
@@ -26,14 +30,13 @@ targets:
           - tftp 0x1000000
         boot_command: >
           bootm
+
       TFTPProviderDriver: {}
       UBootTFTPStrategy: {}
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/genexis_pulse-ex400.yaml
+++ b/targets/genexis_pulse-ex400.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: Genexis Pulse EX400 / Inteno Pulse EX400
+  target: ramips-mt7621
+  profile: genexis_pulse-ex400
 targets:
   main:
     features:
@@ -27,9 +31,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/glinet_gl-mt1300.yaml
+++ b/targets/glinet_gl-mt1300.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: GL.iNet GL-MT1300
+  target: ramips-mt7621
+  profile: glinet_gl-mt1300
 targets:
   main:
     features:

--- a/targets/glinet_gl-mt6000.yaml
+++ b/targets/glinet_gl-mt6000.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: GL.iNet GL-MT6000
+  target: mediatek-filogic
+  profile: glinet_gl-mt6000
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/hpe_msm460.yaml
+++ b/targets/hpe_msm460.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: Hewlett-Packard MSM460
+  target: mpc85xx-p1020
+  profile: hpe_msm460
 targets:
   main:
     features:
@@ -26,9 +30,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/iei_puzzle-m902.yaml
+++ b/targets/iei_puzzle-m902.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: iEi Puzzle-M902
+  target: mvebu-cortexa72
+  profile: iei_puzzle-m902
 targets:
   main:
     features:
@@ -26,9 +30,7 @@ targets:
       - SSHDriver:
           connection_timeout: 120.0
           explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/ignitenet_ss-w2-ac2600.yaml
+++ b/targets/ignitenet_ss-w2-ac2600.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: IgniteNet SunSpot AC Wave2
+  target: ipq806x-generic
+  profile: ignitenet_ss-w2-ac2600
+  snapshots_only: true
 targets:
   main:
     features:
@@ -27,9 +32,7 @@ targets:
       - SSHDriver:
           connection_timeout: 120.0
           explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/librerouter_librerouter-v1.yaml
+++ b/targets/librerouter_librerouter-v1.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: LibreRouter v1
+  target: ath79-generic
+  profile: librerouter_librerouter-v1
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       - SSHDriver:
           connection_timeout: 120.0
           explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/linksprite_a10-pcduino.yaml
+++ b/targets/linksprite_a10-pcduino.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: Linksprite pcDuino 2
+  target: sunxi-cortexa8
+  profile: linksprite_a10-pcduino
+  snapshots_only: true
 targets:
   main:
     resources:
@@ -26,9 +31,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/linksys_e8450.yaml
+++ b/targets/linksys_e8450.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: Linksys E8450 / Belkin RT3200
+  target: mediatek-mt7622
+  profile: linksys_e8450
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/olimex_a10-olinuxino-lime.yaml
+++ b/targets/olimex_a10-olinuxino-lime.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: Olimex A10 Lime
+  target: sunxi-cortexa8
+  profile: olimex_a10-olinuxino-lime
+  snapshots_only: true
 targets:
   main:
     resources:
@@ -26,9 +31,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/olimex_a20-olinuxino-micro.yaml
+++ b/targets/olimex_a20-olinuxino-micro.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: Olimex A20 Micro
+  target: sunxi-cortexa7
+  profile: olimex_a20-olinuxino-micro
+  snapshots_only: true
 targets:
   main:
     resources:
@@ -26,9 +31,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/openwrt_one.yaml
+++ b/targets/openwrt_one.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: OpenWrt One
+  target: mediatek-filogic
+  profile: openwrt_one
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       - SSHDriver:
           connection_timeout: 120.0
           explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/pine64_pine64-plus.yaml
+++ b/targets/pine64_pine64-plus.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: Pine64 Plus
+  target: sunxi-cortexa53
+  profile: pine64_pine64-plus
+  snapshots_only: true
 targets:
   main:
     resources:
@@ -26,9 +31,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/qemu_armsr-armv8.yaml
+++ b/targets/qemu_armsr-armv8.yaml
@@ -1,15 +1,16 @@
+openwrt:
+  target: armsr-armv8
+  profile: generic
 targets:
   main:
     features:
       - wan_port
-
     resources:
       - NetworkService:
           # The actual address will be filled in by the strategy
           address: ""
           port: 22
           username: root
-
     drivers:
       - QEMUDriver:
           qemu_bin: qemu_bin
@@ -28,9 +29,7 @@ targets:
           connection_timeout: 120.0
           explicit_scp_mode: True
       - QEMUNetworkStrategy: {}
-
 tools:
   qemu_bin: qemu-system-aarch64
-
 imports:
   - ../strategies/qemunetworkstrategy.py

--- a/targets/qemu_malta-be.yaml
+++ b/targets/qemu_malta-be.yaml
@@ -1,15 +1,16 @@
+openwrt:
+  target: malta-be
+  profile: generic
 targets:
   main:
     features:
       - wan_port
-
     resources:
       - NetworkService:
           # The actual address will be filled in by the strategy
           address: ""
           port: 22
           username: root
-
     drivers:
       - QEMUDriver:
           qemu_bin: qemu_bin
@@ -28,9 +29,7 @@ targets:
           connection_timeout: 120.0
           explicit_scp_mode: True
       - QEMUNetworkStrategy: {}
-
 tools:
   qemu_bin: qemu-system-mips
-
 imports:
   - ../strategies/qemunetworkstrategy.py

--- a/targets/qemu_malta-be.yaml
+++ b/targets/qemu_malta-be.yaml
@@ -1,6 +1,7 @@
 openwrt:
   target: malta-be
   profile: generic
+  snapshots_only: true
 targets:
   main:
     features:

--- a/targets/qemu_x86-64.yaml
+++ b/targets/qemu_x86-64.yaml
@@ -1,3 +1,10 @@
+openwrt:
+  target: x86-64
+  profile: generic
+  image:
+    type: combined
+    filesystem: squashfs
+
 targets:
   main:
     features:

--- a/targets/rpi-4.yaml
+++ b/targets/rpi-4.yaml
@@ -1,3 +1,10 @@
+openwrt:
+  name: Raspberry Pi 4B/400/CM4 (64bit)
+  target: bcm27xx-bcm2711
+  profile: rpi-4
+  image:
+    type: factory
+    filesystem: squashfs
 targets:
   main:
     resources:
@@ -20,9 +27,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/sdmuxstrategy.py

--- a/targets/tplink_tl-wdr3600-v1.yaml
+++ b/targets/tplink_tl-wdr3600-v1.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: TP-Link TL-WDR3600 v1
+  target: ath79-generic
+  profile: tplink_tl-wdr3600-v1
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/tplink_tl-wdr4300-v1.yaml
+++ b/targets/tplink_tl-wdr4300-v1.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: TP-Link TL-WDR4300 v1
+  target: ath79-generic
+  profile: tplink_tl-wdr4300-v1
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/tplink_tl-wr1043nd-v3.yaml
+++ b/targets/tplink_tl-wr1043nd-v3.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: TP-Link TL-WR1043N/ND v3
+  target: ath79-generic
+  profile: tplink_tl-wr1043nd-v3
 targets:
   main:
     features:
@@ -40,9 +44,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/tplink_tl-wr1043nd-v4.yaml
+++ b/targets/tplink_tl-wr1043nd-v4.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: TP-Link TL-WR1043N/ND v4
+  target: ath79-generic
+  profile: tplink_tl-wr1043nd-v4
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/tplink_tl-wr842n-v3.yaml
+++ b/targets/tplink_tl-wr842n-v3.yaml
@@ -1,3 +1,7 @@
+openwrt:
+  name: TP-Link TL-WR842N v3
+  target: ath79-generic
+  profile: tplink_tl-wr842n-v3
 targets:
   main:
     features:
@@ -28,9 +32,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/xunlong_orangepi-2.yaml
+++ b/targets/xunlong_orangepi-2.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: Orange Pi 2
+  target: sunxi-cortexa7
+  profile: xunlong_orangepi-2
+  snapshots_only: true
 targets:
   main:
     resources:
@@ -26,9 +31,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py

--- a/targets/xunlong_orangepi-zero2.yaml
+++ b/targets/xunlong_orangepi-zero2.yaml
@@ -1,3 +1,8 @@
+openwrt:
+  name: Orange Pi Zero2
+  target: sunxi-cortexa53
+  profile: xunlong_orangepi-zero2
+  snapshots_only: true
 targets:
   main:
     resources:
@@ -26,9 +31,7 @@ targets:
       SSHDriver:
         connection_timeout: 120.0
         explicit_scp_mode: True
-
 images:
   root: !template $LG_IMAGE
-
 imports:
   - ../strategies/tftpstrategy.py


### PR DESCRIPTION
Each targets/*.yaml now carries an openwrt block with target, profile, and image type/filesystem. labnet.yaml devices shed their target and firmware fields, and both workflows use a single profiles.json query for snapshots and stable releases. Fixes the malta-be snapshot job, which referenced a vmlinux-initramfs.elf that no longer ships.