### PR TITLE
fix(openwrt_one): use menu exit key instead of NULL byte as interrupt

### DIFF
--- a/targets/openwrt_one.yaml
+++ b/targets/openwrt_one.yaml
@@ -16,7 +16,7 @@ targets:
       - SerialDriver:
           txdelay: 0.01
       - UBootDriver:
-          interrupt: "\\x0"
+          interrupt: "0"
           prompt: "OpenWrt One>"
           init_commands:
             - dhcp


### PR DESCRIPTION
Hey,

OpenWrt One healthchecks have been flaky for a while on our lab (and it looks like other labs hit the same thing). When it fails, U-Boot sometimes sees `x0echo` instead of `echo` after the interrupt.

We use `interrupt: "\\x0"` to leave the U-Boot menu, but that NULL byte can stick to the next command. The menu already has `0. Exit`, so this switches the interrupt to `"0"`.

One line change, hopefully it should stop the random prompt check failures.

Thanks!